### PR TITLE
baseURL is added at line 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ const submitBtn = document.getElementById('submit-btn');
 
 SDK.configure({
   XIBMClientID: 'YOUR-IBM-Client-ID',
-  XIBMClientSecret: 'YOUR-IBM-Client-Secret'
+  XIBMClientSecret: 'YOUR-IBM-Client-Secret',
+  baseURL: 'https://api.ibm.com/virtualagent/run/api/v1/'
 });
 
 SDK.start( BOT_ID )


### PR DESCRIPTION
baseURL is needed during SDK configuration otherwise SDK.start will not work.